### PR TITLE
feat: implementar HU-10 cotizar motocicleta

### DIFF
--- a/backend/catalog/migrations/0008_hu10_cotizacion_motocicleta.py
+++ b/backend/catalog/migrations/0008_hu10_cotizacion_motocicleta.py
@@ -1,0 +1,96 @@
+from django.conf import settings
+from django.db import migrations, models
+import django.db.models.deletion
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("core", "0002_alter_municipio_id_alter_sede_id_local"),
+        ("catalog", "0007_alter_cotizacionmotocicleta_id_and_more"),
+        migrations.swappable_dependency(settings.AUTH_USER_MODEL),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name="cotizacionmotocicleta",
+            name="usuario",
+            field=models.ForeignKey(
+                blank=True,
+                null=True,
+                on_delete=django.db.models.deletion.PROTECT,
+                to=settings.AUTH_USER_MODEL,
+            ),
+        ),
+        migrations.AddField(
+            model_name="cotizacionmotocicleta",
+            name="cliente_correo",
+            field=models.EmailField(blank=True, default="", max_length=254),
+        ),
+        migrations.AddField(
+            model_name="cotizacionmotocicleta",
+            name="cliente_nombre",
+            field=models.CharField(blank=True, default="", max_length=120),
+        ),
+        migrations.AddField(
+            model_name="cotizacionmotocicleta",
+            name="cliente_telefono",
+            field=models.CharField(blank=True, default="", max_length=20),
+        ),
+        migrations.AddField(
+            model_name="cotizacionmotocicleta",
+            name="correo_cotizacion_enviado",
+            field=models.BooleanField(default=False),
+        ),
+        migrations.AddField(
+            model_name="cotizacionmotocicleta",
+            name="error_envio_cotizacion",
+            field=models.TextField(blank=True, default=""),
+        ),
+        migrations.AddField(
+            model_name="cotizacionmotocicleta",
+            name="fecha_envio_cotizacion",
+            field=models.DateTimeField(blank=True, null=True),
+        ),
+        migrations.AddField(
+            model_name="cotizacionmotocicleta",
+            name="impuestos_estimados",
+            field=models.DecimalField(decimal_places=2, default=0, max_digits=12),
+        ),
+        migrations.AddField(
+            model_name="cotizacionmotocicleta",
+            name="local",
+            field=models.ForeignKey(
+                blank=True,
+                null=True,
+                on_delete=django.db.models.deletion.PROTECT,
+                related_name="cotizaciones_motocicletas",
+                to="core.local",
+            ),
+        ),
+        migrations.AddField(
+            model_name="cotizacionmotocicleta",
+            name="precio_base",
+            field=models.DecimalField(decimal_places=2, default=0, max_digits=12),
+            preserve_default=False,
+        ),
+        migrations.AddField(
+            model_name="cotizacionmotocicleta",
+            name="radicado",
+            field=models.CharField(blank=True, max_length=30, null=True, unique=True),
+        ),
+        migrations.AddField(
+            model_name="cotizacionmotocicleta",
+            name="total_estimado",
+            field=models.DecimalField(decimal_places=2, default=0, max_digits=12),
+            preserve_default=False,
+        ),
+        migrations.AddField(
+            model_name="cotizacionmotocicleta",
+            name="tramites_estimados",
+            field=models.DecimalField(decimal_places=2, default=0, max_digits=12),
+        ),
+        migrations.AlterModelOptions(
+            name="cotizacionmotocicleta",
+            options={"ordering": ["-created_at", "-id"]},
+        ),
+    ]

--- a/backend/catalog/models.py
+++ b/backend/catalog/models.py
@@ -3,6 +3,8 @@
 from django.conf import settings
 from django.db import models
 
+from core.models import Local
+
 
 class Motocicleta(models.Model):
     class TipoMotocicleta(models.TextChoices):
@@ -10,7 +12,7 @@ class Motocicleta(models.Model):
         URBANA = "URBANA", "Urbana"
         TODOTERRENO = "TODOTERRENO", "Todoterreno"
         CUATRIMOTOS = "CUATRIMOTOS", "Cuatrimotos"
-        AUTOMATICA = "AUTOMATICA", "Automáticas y Semiautomáticas"
+        AUTOMATICA = "AUTOMATICA", "Automaticas y Semiautomaticas"
 
     marca = models.CharField(max_length=80, default="Yamaha", editable=False)
     referencia = models.CharField(max_length=80)
@@ -47,14 +49,40 @@ class InteresRepuesto(models.Model):
     created_at = models.DateTimeField(auto_now_add=True)
 
     def __str__(self):
-        return f"{self.usuario} — {self.repuesto} ({self.created_at.date()})"
+        return f"{self.usuario} - {self.repuesto} ({self.created_at.date()})"
 
 
 class CotizacionMotocicleta(models.Model):
-    usuario = models.ForeignKey(settings.AUTH_USER_MODEL, on_delete=models.PROTECT)
+    usuario = models.ForeignKey(
+        settings.AUTH_USER_MODEL,
+        on_delete=models.PROTECT,
+        null=True,
+        blank=True,
+    )
     motocicleta = models.ForeignKey(Motocicleta, on_delete=models.PROTECT)
+    local = models.ForeignKey(
+        Local,
+        on_delete=models.PROTECT,
+        related_name="cotizaciones_motocicletas",
+        null=True,
+        blank=True,
+    )
+    radicado = models.CharField(max_length=30, unique=True, null=True, blank=True)
+    precio_base = models.DecimalField(max_digits=12, decimal_places=2)
+    impuestos_estimados = models.DecimalField(max_digits=12, decimal_places=2, default=0)
+    tramites_estimados = models.DecimalField(max_digits=12, decimal_places=2, default=0)
+    total_estimado = models.DecimalField(max_digits=12, decimal_places=2)
+    cliente_nombre = models.CharField(max_length=120, blank=True, default="")
+    cliente_correo = models.EmailField(blank=True, default="")
+    cliente_telefono = models.CharField(max_length=20, blank=True, default="")
+    correo_cotizacion_enviado = models.BooleanField(default=False)
+    fecha_envio_cotizacion = models.DateTimeField(null=True, blank=True)
+    error_envio_cotizacion = models.TextField(blank=True, default="")
     comentario = models.CharField(max_length=255, blank=True, default="")
     created_at = models.DateTimeField(auto_now_add=True)
 
+    class Meta:
+        ordering = ["-created_at", "-id"]
+
     def __str__(self):
-        return f"Cotización {self.motocicleta} — {self.usuario} ({self.created_at.date()})"
+        return f"{self.radicado or 'SIN-RADICADO'} - {self.motocicleta}"

--- a/backend/catalog/serializers.py
+++ b/backend/catalog/serializers.py
@@ -5,7 +5,8 @@ from datetime import date
 
 from rest_framework import serializers
 
-from catalog.models import Motocicleta
+from catalog.models import CotizacionMotocicleta, Motocicleta
+from core.models import Local
 
 
 class MotocicletaSerializer(serializers.ModelSerializer):
@@ -16,7 +17,7 @@ class MotocicletaSerializer(serializers.ModelSerializer):
     referencia = serializers.CharField(
         error_messages={
             "required": "La referencia es obligatoria.",
-            "blank": "La referencia no puede estar vacía.",
+            "blank": "La referencia no puede estar vacia.",
         }
     )
     cilindraje = serializers.IntegerField(
@@ -26,7 +27,7 @@ class MotocicletaSerializer(serializers.ModelSerializer):
             "min_value": "El cilindraje debe ser mayor a 0.",
         },
     )
-    anio = serializers.IntegerField(error_messages={"required": "El año es obligatorio."})
+    anio = serializers.IntegerField(error_messages={"required": "El anio es obligatorio."})
     precio = serializers.DecimalField(
         max_digits=12,
         decimal_places=2,
@@ -34,8 +35,8 @@ class MotocicletaSerializer(serializers.ModelSerializer):
     )
     caracteristicas = serializers.CharField(
         error_messages={
-            "required": "Las características son obligatorias.",
-            "blank": "Las características no pueden estar vacías.",
+            "required": "Las caracteristicas son obligatorias.",
+            "blank": "Las caracteristicas no pueden estar vacias.",
         }
     )
 
@@ -56,16 +57,14 @@ class MotocicletaSerializer(serializers.ModelSerializer):
         read_only_fields = ["id", "marca", "activa"]
 
     def to_internal_value(self, data):
-        """Trunca el nombre del archivo ANTES de que DRF valide max_length del campo imagen."""
         imagen = data.get("imagen")
         if hasattr(imagen, "name") and len(imagen.name) > 100:
-            extension = os.path.splitext(imagen.name)[1]  # ej. '.png'
+            extension = os.path.splitext(imagen.name)[1]
             max_base = 99 - len(extension)
-            imagen.name = imagen.name[:max_base] + extension  # resultado ≤ 100 chars
+            imagen.name = imagen.name[:max_base] + extension
         return super().to_internal_value(data)
 
     def validate_imagen(self, value):
-        """Valida tamaño máximo: 5 MB."""
         if value and hasattr(value, "size") and value.size > 5 * 1024 * 1024:
             raise serializers.ValidationError("La imagen no puede superar los 5 MB.")
         return value
@@ -78,7 +77,7 @@ class MotocicletaSerializer(serializers.ModelSerializer):
     def validate_anio(self, value):
         anio_actual = date.today().year
         if value < 1900 or value > anio_actual + 1:
-            raise serializers.ValidationError(f"Ingrese un año válido entre 1900 y {anio_actual + 1}.")
+            raise serializers.ValidationError(f"Ingrese un anio valido entre 1900 y {anio_actual + 1}.")
         return value
 
     def validate_precio(self, value):
@@ -88,16 +87,12 @@ class MotocicletaSerializer(serializers.ModelSerializer):
 
 
 class MotocicletaEstadoSerializer(serializers.ModelSerializer):
-    """Serializer de solo lectura para respuestas de cambio de estado — HU-15"""
-
     class Meta:
         model = Motocicleta
         fields = ["id", "marca", "referencia", "anio", "activa"]
 
 
 class MotocicletaListSerializer(serializers.ModelSerializer):
-    """Serializer de solo lectura para el catálogo público — HU-11"""
-
     imagen_url = serializers.SerializerMethodField()
     precio_display = serializers.SerializerMethodField()
     tipo_display = serializers.SerializerMethodField()
@@ -130,3 +125,93 @@ class MotocicletaListSerializer(serializers.ModelSerializer):
 
     def get_tipo_display(self, obj):
         return obj.get_tipo_display()
+
+
+class CotizarMotocicletaSerializer(serializers.Serializer):
+    motocicleta_id = serializers.IntegerField(error_messages={"required": "La motocicleta es obligatoria."})
+    local_id = serializers.IntegerField(required=False, allow_null=True)
+    cliente_nombre = serializers.CharField(required=False, allow_blank=True, max_length=120)
+    cliente_correo = serializers.EmailField(required=False, allow_blank=True)
+    cliente_telefono = serializers.CharField(required=False, allow_blank=True, max_length=20)
+    comentario = serializers.CharField(required=False, allow_blank=True, max_length=255)
+
+    def validate_motocicleta_id(self, value):
+        try:
+            motocicleta = Motocicleta.objects.get(pk=value, activa=True)
+        except Motocicleta.DoesNotExist as exc:
+            raise serializers.ValidationError("La motocicleta seleccionada no existe o no esta disponible.") from exc
+
+        if motocicleta.precio <= 0:
+            raise serializers.ValidationError("La motocicleta seleccionada no tiene un precio valido para cotizar.")
+
+        self.context["motocicleta"] = motocicleta
+        return value
+
+    def validate_local_id(self, value):
+        if value in (None, ""):
+            self.context["local"] = None
+            return None
+
+        try:
+            local = Local.objects.get(pk=value, activo=True)
+        except Local.DoesNotExist as exc:
+            raise serializers.ValidationError("El local seleccionado no existe o no esta disponible.") from exc
+
+        self.context["local"] = local
+        return value
+
+    def validate_cliente_nombre(self, value):
+        return value.strip()
+
+    def validate_cliente_telefono(self, value):
+        return value.strip()
+
+    def validate_comentario(self, value):
+        return value.strip()
+
+
+class CotizacionMotocicletaResponseSerializer(serializers.ModelSerializer):
+    motocicleta = serializers.SerializerMethodField()
+    local = serializers.SerializerMethodField()
+    whatsapp_url = serializers.CharField(read_only=True)
+
+    class Meta:
+        model = CotizacionMotocicleta
+        fields = [
+            "id",
+            "radicado",
+            "motocicleta",
+            "local",
+            "precio_base",
+            "impuestos_estimados",
+            "tramites_estimados",
+            "total_estimado",
+            "cliente_nombre",
+            "cliente_correo",
+            "cliente_telefono",
+            "comentario",
+            "correo_cotizacion_enviado",
+            "fecha_envio_cotizacion",
+            "whatsapp_url",
+            "created_at",
+        ]
+
+    def get_motocicleta(self, obj):
+        return {
+            "id": obj.motocicleta_id,
+            "marca": obj.motocicleta.marca,
+            "referencia": obj.motocicleta.referencia,
+            "anio": obj.motocicleta.anio,
+            "tipo": obj.motocicleta.tipo,
+            "cilindraje": obj.motocicleta.cilindraje,
+        }
+
+    def get_local(self, obj):
+        if obj.local is None:
+            return None
+        return {
+            "id": obj.local_id,
+            "nombre": obj.local.nombre,
+            "direccion": obj.local.direccion,
+            "telefono": obj.local.telefono,
+        }

--- a/backend/catalog/services.py
+++ b/backend/catalog/services.py
@@ -1,0 +1,120 @@
+from decimal import Decimal, ROUND_HALF_UP
+import re
+from urllib.parse import quote
+
+from django.conf import settings
+from django.core.mail import send_mail
+from django.utils import timezone
+
+from catalog.models import CotizacionMotocicleta
+
+IMPUESTO_RATE = Decimal("0.19")
+TRAMITES_RATE = Decimal("0.08")
+MONEY_STEP = Decimal("0.01")
+
+
+def _money(value: Decimal) -> Decimal:
+    return value.quantize(MONEY_STEP, rounding=ROUND_HALF_UP)
+
+
+def generar_radicado_cotizacion() -> str:
+    base = timezone.localtime().strftime("COT-%Y%m%d-%H%M%S")
+    sufijo = 1
+    codigo = f"{base}-{sufijo:02d}"
+    while CotizacionMotocicleta.objects.filter(radicado=codigo).exists():
+        sufijo += 1
+        codigo = f"{base}-{sufijo:02d}"
+    return codigo
+
+
+def calcular_desglose_cotizacion(precio_base: Decimal) -> dict[str, Decimal]:
+    impuestos_estimados = _money(precio_base * IMPUESTO_RATE)
+    tramites_estimados = _money(precio_base * TRAMITES_RATE)
+    total_estimado = _money(precio_base + impuestos_estimados + tramites_estimados)
+    return {
+        "precio_base": _money(precio_base),
+        "impuestos_estimados": impuestos_estimados,
+        "tramites_estimados": tramites_estimados,
+        "total_estimado": total_estimado,
+    }
+
+
+def construir_enlace_whatsapp(telefono: str, radicado: str, nombre_motocicleta: str) -> str:
+    numero = re.sub(r"\D", "", telefono or "")
+    if len(numero) == 10:
+        numero = f"57{numero}"
+
+    mensaje = (
+        f"Hola, quiero continuar la atencion de mi cotizacion {radicado} para la motocicleta {nombre_motocicleta}."
+    )
+    return f"https://wa.me/{numero}?text={quote(mensaje)}"
+
+
+def enviar_cotizacion_por_correo(cotizacion: CotizacionMotocicleta) -> bool:
+    if not cotizacion.cliente_correo:
+        cotizacion.correo_cotizacion_enviado = False
+        cotizacion.fecha_envio_cotizacion = None
+        cotizacion.error_envio_cotizacion = ""
+        cotizacion.save(
+            update_fields=[
+                "correo_cotizacion_enviado",
+                "fecha_envio_cotizacion",
+                "error_envio_cotizacion",
+            ]
+        )
+        return False
+
+    try:
+        moto = cotizacion.motocicleta
+        asunto = f"Cotizacion {cotizacion.radicado} - Rallye Motor's"
+        local_nombre = cotizacion.local.nombre if cotizacion.local else "Pendiente por definir"
+        local_direccion = cotizacion.local.direccion if cotizacion.local else "Pendiente por definir"
+        mensaje = f"""Hola {cotizacion.cliente_nombre or "cliente"},
+
+Tu cotizacion de motocicleta fue generada exitosamente.
+
+DETALLES DE LA COTIZACION
+Radicado:           {cotizacion.radicado}
+Motocicleta:        Yamaha {moto.referencia} {moto.anio}
+Local de interes:   {local_nombre}
+Direccion:          {local_direccion}
+Precio base:        ${cotizacion.precio_base}
+Impuestos:          ${cotizacion.impuestos_estimados}
+Tramites:           ${cotizacion.tramites_estimados}
+Total estimado:     ${cotizacion.total_estimado}
+
+Cuando haya un local asignado, podras continuar la atencion por WhatsApp.
+
+Equipo Rallye Motor's
+"""
+        send_mail(
+            subject=asunto,
+            message=mensaje,
+            from_email=settings.DEFAULT_FROM_EMAIL,
+            recipient_list=[cotizacion.cliente_correo],
+            fail_silently=False,
+        )
+
+        cotizacion.correo_cotizacion_enviado = True
+        cotizacion.fecha_envio_cotizacion = timezone.now()
+        cotizacion.error_envio_cotizacion = ""
+        cotizacion.save(
+            update_fields=[
+                "correo_cotizacion_enviado",
+                "fecha_envio_cotizacion",
+                "error_envio_cotizacion",
+            ]
+        )
+        return True
+    except Exception as exc:
+        cotizacion.correo_cotizacion_enviado = False
+        cotizacion.fecha_envio_cotizacion = timezone.now()
+        cotizacion.error_envio_cotizacion = str(exc)
+        cotizacion.save(
+            update_fields=[
+                "correo_cotizacion_enviado",
+                "fecha_envio_cotizacion",
+                "error_envio_cotizacion",
+            ]
+        )
+        return False

--- a/backend/catalog/tests.py
+++ b/backend/catalog/tests.py
@@ -1,11 +1,15 @@
 # catalog/tests.py
 
+from decimal import Decimal
+
 from django.contrib.auth import get_user_model
+from django.core import mail
 from django.test import TestCase
+from django.urls import reverse
 from rest_framework.test import APIClient
 from rest_framework_simplejwt.tokens import RefreshToken
 
-from catalog.models import Motocicleta
+from catalog.models import CotizacionMotocicleta, Motocicleta
 from core.models import Local, Municipio, Sede
 
 User = get_user_model()
@@ -258,8 +262,167 @@ class VisualizarCatalogoTest(TestCase):
         self.assertEqual(response.status_code, 200)
         tipos = [m["tipo_display"] for m in response.data]
         self.assertIn("Deportiva", tipos)
-        self.assertIn("Todoterreno", tipos)
-        self.assertNotIn("Urbana", tipos)  # la moto urbana está inactiva
+
+
+class CotizarMotocicletaTest(TestCase):
+    def setUp(self):
+        self.client = APIClient()
+        self.url = reverse("cotizar_moto")
+        self.local = make_local()
+        self.motocicleta = Motocicleta.objects.create(
+            referencia="FZ 150",
+            anio=2026,
+            tipo="URBANA",
+            cilindraje=150,
+            precio=Decimal("10000000.00"),
+            caracteristicas="Moto urbana para uso diario.",
+            activa=True,
+        )
+
+    def _payload_valido(self):
+        return {
+            "motocicleta_id": self.motocicleta.id,
+            "cliente_nombre": "Juan Perez",
+            "cliente_correo": "juan@test.com",
+            "cliente_telefono": "3004567890",
+            "comentario": "Deseo financiar la compra",
+        }
+
+    def test_cp_hu10_01_crea_cotizacion_con_desglose_y_radicado_sin_local(self):
+        with self.settings(EMAIL_BACKEND="django.core.mail.backends.locmem.EmailBackend"):
+            response = self.client.post(self.url, self._payload_valido(), format="json")
+
+        self.assertEqual(response.status_code, 201)
+        self.assertTrue(response.data["radicado"].startswith("COT-"))
+        self.assertEqual(response.data["precio_base"], "10000000.00")
+        self.assertEqual(response.data["impuestos_estimados"], "1900000.00")
+        self.assertEqual(response.data["tramites_estimados"], "800000.00")
+        self.assertEqual(response.data["total_estimado"], "12700000.00")
+        self.assertIsNone(response.data["local"])
+        self.assertIsNone(response.data["whatsapp_url"])
+        self.assertEqual(CotizacionMotocicleta.objects.count(), 1)
+
+    def test_cp_hu10_02_guarda_datos_correctos_en_bd(self):
+        with self.settings(EMAIL_BACKEND="django.core.mail.backends.locmem.EmailBackend"):
+            self.client.post(self.url, self._payload_valido(), format="json")
+
+        cotizacion = CotizacionMotocicleta.objects.get()
+        self.assertEqual(cotizacion.motocicleta, self.motocicleta)
+        self.assertIsNone(cotizacion.local)
+        self.assertEqual(cotizacion.cliente_nombre, "Juan Perez")
+        self.assertEqual(cotizacion.cliente_correo, "juan@test.com")
+        self.assertEqual(cotizacion.cliente_telefono, "3004567890")
+        self.assertEqual(cotizacion.total_estimado, Decimal("12700000.00"))
+
+    def test_cp_hu10_03_correo_se_envia_si_cliente_ingresa_email(self):
+        with self.settings(EMAIL_BACKEND="django.core.mail.backends.locmem.EmailBackend"):
+            response = self.client.post(self.url, self._payload_valido(), format="json")
+
+        self.assertEqual(response.status_code, 201)
+        self.assertEqual(len(mail.outbox), 1)
+        correo = mail.outbox[0]
+        self.assertIn(response.data["radicado"], correo.subject)
+        self.assertEqual(correo.to, ["juan@test.com"])
+
+        cotizacion = CotizacionMotocicleta.objects.get()
+        self.assertTrue(cotizacion.correo_cotizacion_enviado)
+        self.assertIsNotNone(cotizacion.fecha_envio_cotizacion)
+
+    def test_cp_hu10_04_no_envia_correo_si_no_hay_email(self):
+        payload = self._payload_valido()
+        payload["cliente_correo"] = ""
+
+        with self.settings(EMAIL_BACKEND="django.core.mail.backends.locmem.EmailBackend"):
+            response = self.client.post(self.url, payload, format="json")
+
+        self.assertEqual(response.status_code, 201)
+        self.assertEqual(len(mail.outbox), 0)
+        cotizacion = CotizacionMotocicleta.objects.get()
+        self.assertFalse(cotizacion.correo_cotizacion_enviado)
+        self.assertIsNone(cotizacion.fecha_envio_cotizacion)
+
+    def test_cp_hu10_05_motocicleta_inexistente_retorna_400(self):
+        payload = self._payload_valido()
+        payload["motocicleta_id"] = 99999
+
+        response = self.client.post(self.url, payload, format="json")
+
+        self.assertEqual(response.status_code, 400)
+        self.assertIn("motocicleta_id", response.data)
+        self.assertFalse(CotizacionMotocicleta.objects.exists())
+
+    def test_cp_hu10_06_motocicleta_inactiva_retorna_400(self):
+        self.motocicleta.activa = False
+        self.motocicleta.save(update_fields=["activa"])
+
+        response = self.client.post(self.url, self._payload_valido(), format="json")
+
+        self.assertEqual(response.status_code, 400)
+        self.assertIn("motocicleta_id", response.data)
+
+    def test_cp_hu10_07_local_inactivo_retorna_400_si_se_envia(self):
+        self.local.activo = False
+        self.local.save(update_fields=["activo"])
+        payload = self._payload_valido()
+        payload["local_id"] = self.local.id
+
+        response = self.client.post(self.url, payload, format="json")
+
+        self.assertEqual(response.status_code, 400)
+        self.assertIn("local_id", response.data)
+
+    def test_cp_hu10_08_con_local_retorna_whatsapp(self):
+        payload = self._payload_valido()
+        payload["local_id"] = self.local.id
+
+        with self.settings(EMAIL_BACKEND="django.core.mail.backends.locmem.EmailBackend"):
+            response = self.client.post(self.url, payload, format="json")
+
+        self.assertEqual(response.status_code, 201)
+        self.assertEqual(response.data["local"]["id"], self.local.id)
+        self.assertIn("https://wa.me/573001234567", response.data["whatsapp_url"])
+
+    def test_cp_hu10_09_usuario_autenticado_queda_asociado(self):
+        admin = make_admin(self.local)
+        self.client.credentials(HTTP_AUTHORIZATION=f"Bearer {get_token(admin)}")
+
+        with self.settings(EMAIL_BACKEND="django.core.mail.backends.locmem.EmailBackend"):
+            response = self.client.post(self.url, self._payload_valido(), format="json")
+
+        self.assertEqual(response.status_code, 201)
+        cotizacion = CotizacionMotocicleta.objects.get()
+        self.assertEqual(cotizacion.usuario, admin)
+
+    def test_cp_hu10_10_usuario_anonimo_puede_cotizar(self):
+        with self.settings(EMAIL_BACKEND="django.core.mail.backends.locmem.EmailBackend"):
+            response = self.client.post(self.url, self._payload_valido(), format="json")
+
+        self.assertEqual(response.status_code, 201)
+        cotizacion = CotizacionMotocicleta.objects.get()
+        self.assertIsNone(cotizacion.usuario)
+
+    def test_cp_hu10_11_campos_texto_se_normalizan(self):
+        payload = self._payload_valido()
+        payload["cliente_nombre"] = "  Juan Perez  "
+        payload["cliente_telefono"] = " 3004567890 "
+        payload["comentario"] = "  Quiero entrega inmediata  "
+
+        with self.settings(EMAIL_BACKEND="django.core.mail.backends.locmem.EmailBackend"):
+            self.client.post(self.url, payload, format="json")
+
+        cotizacion = CotizacionMotocicleta.objects.get()
+        self.assertEqual(cotizacion.cliente_nombre, "Juan Perez")
+        self.assertEqual(cotizacion.cliente_telefono, "3004567890")
+        self.assertEqual(cotizacion.comentario, "Quiero entrega inmediata")
+
+    def test_cp_hu10_12_radicados_son_unicos(self):
+        with self.settings(EMAIL_BACKEND="django.core.mail.backends.locmem.EmailBackend"):
+            response_1 = self.client.post(self.url, self._payload_valido(), format="json")
+            response_2 = self.client.post(self.url, self._payload_valido(), format="json")
+
+        self.assertEqual(response_1.status_code, 201)
+        self.assertEqual(response_2.status_code, 201)
+        self.assertNotEqual(response_1.data["radicado"], response_2.data["radicado"])
 
 
 # ── HU-12 · Filtrar catálogo ─────────────────────────────────────────────────

--- a/backend/catalog/urls.py
+++ b/backend/catalog/urls.py
@@ -1,16 +1,19 @@
 # catalog/urls.py
 
 from django.urls import path
+
 from catalog.views import (
-    AgregarMotocicletaView,
     ActivarMotocicletaView,
+    AgregarMotocicletaView,
     CatalogoMotocicletasView,
+    CotizarMotocicletaView,
     DesactivarMotocicletaView,
     EditarMotocicletaView,
     ListadoAdminMotocicletasView,
 )
 
 urlpatterns = [
+    path("cotizaciones/motocicletas/", CotizarMotocicletaView.as_view(), name="cotizar_moto"),
     path("motocicletas/agregar/", AgregarMotocicletaView.as_view(), name="agregar_moto"),
     path("motocicletas/admin/", ListadoAdminMotocicletasView.as_view(), name="admin_motos"),
     path("motocicletas/<int:pk>/editar/", EditarMotocicletaView.as_view(), name="editar_moto"),

--- a/backend/catalog/views.py
+++ b/backend/catalog/views.py
@@ -6,12 +6,24 @@ from rest_framework.permissions import AllowAny, IsAuthenticated
 from rest_framework.response import Response
 from rest_framework.views import APIView
 
-from catalog.models import Motocicleta
-from catalog.serializers import MotocicletaEstadoSerializer, MotocicletaListSerializer, MotocicletaSerializer
+from catalog.models import CotizacionMotocicleta, Motocicleta
+from catalog.serializers import (
+    CotizacionMotocicletaResponseSerializer,
+    CotizarMotocicletaSerializer,
+    MotocicletaEstadoSerializer,
+    MotocicletaListSerializer,
+    MotocicletaSerializer,
+)
+from catalog.services import (
+    calcular_desglose_cotizacion,
+    construir_enlace_whatsapp,
+    enviar_cotizacion_por_correo,
+    generar_radicado_cotizacion,
+)
 
 
 class AgregarMotocicletaView(APIView):
-    """POST /api/catalog/motocicletas/agregar/ — HU-13"""
+    """POST /api/catalog/motocicletas/agregar/ - HU-13"""
 
     permission_classes = [IsAuthenticated]
     parser_classes = [MultiPartParser, FormParser, JSONParser]
@@ -22,7 +34,7 @@ class AgregarMotocicletaView(APIView):
             motocicleta = serializer.save(activa=True)
             return Response(
                 {
-                    "mensaje": "Motocicleta agregada al catálogo correctamente.",
+                    "mensaje": "Motocicleta agregada al catalogo correctamente.",
                     "id": motocicleta.id,
                 },
                 status=status.HTTP_201_CREATED,
@@ -30,14 +42,52 @@ class AgregarMotocicletaView(APIView):
         return Response(serializer.errors, status=status.HTTP_400_BAD_REQUEST)
 
 
-# ── HU-14 ─────────────────────────────────────────────────────────────────────
-class EditarMotocicletaView(APIView):
-    """
-    GET   /api/catalog/motocicletas/<pk>/editar/  — Carga datos actuales
-    PUT   /api/catalog/motocicletas/<pk>/editar/  — Actualiza todos los campos
-    PATCH /api/catalog/motocicletas/<pk>/editar/  — Actualiza campos parcialmente
-    """
+class CotizarMotocicletaView(APIView):
+    """POST /api/catalog/cotizaciones/motocicletas/ - HU-10"""
 
+    permission_classes = [AllowAny]
+
+    def post(self, request):
+        serializer = CotizarMotocicletaSerializer(data=request.data)
+        if not serializer.is_valid():
+            return Response(serializer.errors, status=status.HTTP_400_BAD_REQUEST)
+
+        motocicleta = serializer.context["motocicleta"]
+        local = serializer.context.get("local")
+        desglose = calcular_desglose_cotizacion(motocicleta.precio)
+        radicado = generar_radicado_cotizacion()
+
+        cotizacion = CotizacionMotocicleta.objects.create(
+            usuario=request.user if request.user.is_authenticated else None,
+            motocicleta=motocicleta,
+            local=local,
+            radicado=radicado,
+            precio_base=desglose["precio_base"],
+            impuestos_estimados=desglose["impuestos_estimados"],
+            tramites_estimados=desglose["tramites_estimados"],
+            total_estimado=desglose["total_estimado"],
+            cliente_nombre=serializer.validated_data.get("cliente_nombre", ""),
+            cliente_correo=serializer.validated_data.get("cliente_correo", ""),
+            cliente_telefono=serializer.validated_data.get("cliente_telefono", ""),
+            comentario=serializer.validated_data.get("comentario", ""),
+        )
+
+        correo_enviado = enviar_cotizacion_por_correo(cotizacion)
+        whatsapp_url = None
+        if local:
+            whatsapp_url = construir_enlace_whatsapp(
+                local.telefono,
+                cotizacion.radicado,
+                f"{motocicleta.marca} {motocicleta.referencia} {motocicleta.anio}",
+            )
+
+        response_data = CotizacionMotocicletaResponseSerializer(cotizacion).data
+        response_data["whatsapp_url"] = whatsapp_url
+        response_data["correo_cotizacion_enviado"] = correo_enviado
+        return Response(response_data, status=status.HTTP_201_CREATED)
+
+
+class EditarMotocicletaView(APIView):
     permission_classes = [IsAuthenticated]
     parser_classes = [MultiPartParser, FormParser, JSONParser]
 
@@ -92,7 +142,12 @@ class EditarMotocicletaView(APIView):
                 {"error": "Motocicleta no encontrada."},
                 status=status.HTTP_404_NOT_FOUND,
             )
-        serializer = MotocicletaSerializer(moto, data=request.data, partial=True, context={"request": request})
+        serializer = MotocicletaSerializer(
+            moto,
+            data=request.data,
+            partial=True,
+            context={"request": request},
+        )
         if serializer.is_valid():
             serializer.save()
             return Response(
@@ -105,11 +160,8 @@ class EditarMotocicletaView(APIView):
         return Response(serializer.errors, status=status.HTTP_400_BAD_REQUEST)
 
 
-# ──────────────────────────────────────────────────────────────────────────────
-
-
 class CatalogoMotocicletasView(APIView):
-    """GET /api/catalog/motocicletas/ — HU-11 + HU-12"""
+    """GET /api/catalog/motocicletas/ - HU-11 + HU-12"""
 
     permission_classes = [AllowAny]
 
@@ -125,7 +177,7 @@ class CatalogoMotocicletasView(APIView):
             motos = motos.filter(referencia__icontains=referencia)
 
         if tipo:
-            tipos_validos = [t[0] for t in Motocicleta.TipoMotocicleta.choices]
+            tipos_validos = [opcion[0] for opcion in Motocicleta.TipoMotocicleta.choices]
             if tipo not in tipos_validos:
                 return Response([], status=status.HTTP_200_OK)
             motos = motos.filter(tipo=tipo)
@@ -140,14 +192,7 @@ class CatalogoMotocicletasView(APIView):
         return Response(serializer.data, status=status.HTTP_200_OK)
 
 
-# ── HU-15 ─────────────────────────────────────────────────────────────────────
 class DesactivarMotocicletaView(APIView):
-    """
-    PATCH /api/catalog/motocicletas/<pk>/desactivar/ — HU-15
-    Desactiva una motocicleta del catálogo público.
-    Solo accesible por usuarios autenticados (administrador del local).
-    """
-
     permission_classes = [IsAuthenticated]
 
     def _get_motocicleta(self, pk):
@@ -180,14 +225,7 @@ class DesactivarMotocicletaView(APIView):
         )
 
 
-# ── HU-15 (activar) ───────────────────────────────────────────────────────────
 class ActivarMotocicletaView(APIView):
-    """
-    PATCH /api/catalog/motocicletas/<pk>/activar/ — HU-15
-    Reactiva una motocicleta del catálogo público.
-    Solo accesible por usuarios autenticados (administrador del local).
-    """
-
     permission_classes = [IsAuthenticated]
 
     def _get_motocicleta(self, pk):
@@ -220,14 +258,7 @@ class ActivarMotocicletaView(APIView):
         )
 
 
-# ── HU-15 (listado admin — todas las motos) ───────────────────────────────────
 class ListadoAdminMotocicletasView(APIView):
-    """
-    GET /api/catalog/motocicletas/admin/ — HU-15
-    Retorna todas las motocicletas (activas e inactivas) para el panel admin.
-    Solo accesible por usuarios autenticados.
-    """
-
     permission_classes = [IsAuthenticated]
 
     def get(self, request):

--- a/frontend/templates/public/motos.html
+++ b/frontend/templates/public/motos.html
@@ -403,6 +403,43 @@
     .cat-modal-cta:disabled, .cat-modal-cta.disabled { opacity: 0.4; cursor: not-allowed; pointer-events: none; }
     .cat-modal-cta svg { width: 16px; height: 16px; stroke: #fff; fill: none; flex-shrink: 0; }
     .cat-modal-sede-hint { font-family: 'DM Sans', sans-serif; font-size: 0.68rem; color: #444; line-height: 1.4; }
+    .cat-cot-form { margin-top: auto; padding-top: 0.9rem; border-top: 1px solid #2a2a2a; display: flex; flex-direction: column; gap: 0.75rem; }
+    .cat-cot-title { font-family: 'Barlow Condensed', sans-serif; font-size: 1.45rem; font-weight: 800; color: #fff; text-transform: uppercase; line-height: 1; }
+    .cat-cot-sub { font-family: 'DM Sans', sans-serif; font-size: 0.8rem; color: #777; line-height: 1.5; }
+    .cat-cot-grid { display: grid; grid-template-columns: 1fr 1fr; gap: 0.75rem; }
+    .cat-cot-field { display: flex; flex-direction: column; gap: 0.35rem; }
+    .cat-cot-field.full { grid-column: 1 / -1; }
+    .cat-cot-label { font-family: 'Barlow Condensed', sans-serif; font-size: 0.68rem; font-weight: 700; letter-spacing: 0.12em; text-transform: uppercase; color: #666; }
+    .cat-cot-input, .cat-cot-select {
+        width: 100%; background: #222; border: 1.5px solid #333; border-radius: 8px;
+        color: #ddd; font-family: 'DM Sans', sans-serif; font-size: 0.9rem;
+        padding: 0.75rem 0.85rem; outline: none; transition: border-color 0.15s, box-shadow 0.15s;
+    }
+    .cat-cot-select {
+        appearance: none; -webkit-appearance: none; padding-right: 2.2rem;
+        background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' fill='none' stroke='%23666' stroke-width='2'%3E%3Cpolyline points='6 9 12 15 18 9'/%3E%3C/svg%3E");
+        background-repeat: no-repeat; background-position: right 0.7rem center; background-size: 14px;
+    }
+    .cat-cot-input:focus, .cat-cot-select:focus { border-color: #cc0000; box-shadow: 0 0 0 3px rgba(204,0,0,0.08); }
+    .cat-cot-actions { display: flex; gap: 0.7rem; margin-top: 0.2rem; }
+    .cat-cot-secondary {
+        display: inline-flex; align-items: center; justify-content: center; gap: 0.45rem;
+        width: 100%; padding: 0.82rem 1.1rem; background: transparent; color: #bbb;
+        border: 1px solid #333; border-radius: 8px; font-family: 'Barlow Condensed', sans-serif;
+        font-size: 0.95rem; font-weight: 700; letter-spacing: 0.12em; text-transform: uppercase; cursor: pointer;
+        transition: border-color 0.15s, color 0.15s, background 0.15s;
+    }
+    .cat-cot-secondary:hover { border-color: #666; color: #fff; background: #202020; }
+    .cat-cot-msg { min-height: 1.15rem; font-family: 'DM Sans', sans-serif; font-size: 0.78rem; line-height: 1.4; }
+    .cat-cot-msg.error { color: #ff6b6b; }
+    .cat-cot-msg.success { color: #83d483; }
+    .cat-cot-summary { margin-top: auto; padding-top: 0.9rem; border-top: 1px solid #2a2a2a; display: flex; flex-direction: column; gap: 0.8rem; }
+    .cat-cot-summary-grid { display: grid; grid-template-columns: 1fr 1fr; gap: 0.6rem; }
+    .cat-cot-summary-card { background: #202020; border: 1px solid #2f2f2f; border-radius: 10px; padding: 0.8rem 0.9rem; }
+    .cat-cot-summary-card.full { grid-column: 1 / -1; }
+    .cat-cot-summary-label { display: block; font-family: 'Barlow Condensed', sans-serif; font-size: 0.62rem; font-weight: 700; letter-spacing: 0.12em; text-transform: uppercase; color: #666; margin-bottom: 0.2rem; }
+    .cat-cot-summary-value { display: block; font-family: 'Barlow Condensed', sans-serif; font-size: 1.02rem; font-weight: 700; color: #f1f1f1; }
+    .cat-cot-summary-total { color: #cc0000; font-size: 1.25rem; }
 
     @media (max-width: 640px) {
         .cat-modal-inner { grid-template-columns: 1fr; }
@@ -410,6 +447,8 @@
         .cat-modal-moto-img { max-height: 150px; }
         .cat-modal-right { padding: 1.2rem 1.1rem 1.4rem; }
         .cat-modal-nombre { font-size: 1.5rem; }
+        .cat-cot-grid, .cat-cot-summary-grid { grid-template-columns: 1fr; }
+        .cat-cot-actions { flex-direction: column; }
         .cat-grid { grid-template-columns: 1fr; }
         .cat-cc-row { gap: 0.35rem; }
         .cat-cc-input { width: 75px; }
@@ -516,9 +555,11 @@
 <script>
     const API_MOTOS = '/api/catalog/motocicletas/';
     const API_SEDES = '/api/core/sedes/';
+    const API_COTIZAR = '/api/catalog/cotizaciones/motocicletas/';
 
     let todasLasMotos = [];
     let todasLasSedes = [];
+    let motoActual = null;
 
     /* ── Estado de filtros ── */
     const filtros = {
@@ -724,7 +765,7 @@
     /* ── Render ── */
     function buildSelectOptions() {
         if (!todasLasSedes.length) {
-            return `<option value="" disabled selected>Sin sedes disponibles</option>`;
+            return `<option value="" selected>Sin sedes disponibles</option>`;
         }
         let html = `<option value="" disabled selected>Selecciona local cercano...</option>`;
         todasLasSedes.forEach(sede => {
@@ -784,9 +825,8 @@
     }
 
     /* ── Modal ── */
-    function abrirModal(id) {
-        const moto = todasLasMotos.find(m => m.id === id);
-        if (!moto) return;
+    function renderModalFormulario(moto) {
+        motoActual = moto;
 
         const imgHtml = moto.imagen_url
             ? `<img class="cat-modal-moto-img" src="${moto.imagen_url}" alt="${moto.referencia}">`
@@ -804,6 +844,26 @@
 
         const precioTexto = (moto.precio_display || '').replace(/^\$\s*/, '');
         const selectOpts  = buildSelectOptions();
+        const haySedes = todasLasSedes.some(sede => sede.locales && sede.locales.length);
+        const sedeHint = haySedes
+            ? 'Selecciona el local más cercano a ti para continuar con la cotización.'
+            : '';
+        const sedeSection = haySedes
+            ? `
+                        <div class="cat-cot-field full">
+                            <span class="cat-modal-sede-label">
+                                <svg viewBox="0 0 24 24" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+                                    <path d="M21 10c0 7-9 13-9 13s-9-6-9-13a9 9 0 0 1 18 0z"/>
+                                    <circle cx="12" cy="10" r="3"/>
+                                </svg>
+                                ¿En qué sede te encuentras?
+                            </span>
+                            <select class="cat-cot-select" id="sedeSelect" onchange="onSedeChange()">
+                                ${selectOpts}
+                            </select>
+                            <span class="cat-modal-sede-hint">${sedeHint}</span>
+                        </div>`
+            : '';
 
         modalContent.innerHTML = `
             <div class="cat-modal-left">
@@ -837,28 +897,59 @@
                 </div>
                 <p class="cat-modal-desc-title">Especificaciones técnicas</p>
                 <p class="cat-modal-desc-text">${moto.caracteristicas || 'Sin descripción disponible.'}</p>
-                <div class="cat-modal-sede-wrap">
-                    <span class="cat-modal-sede-label">
-                        <svg viewBox="0 0 24 24" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
-                            <path d="M21 10c0 7-9 13-9 13s-9-6-9-13a9 9 0 0 1 18 0z"/>
-                            <circle cx="12" cy="10" r="3"/>
-                        </svg>
-                        ¿En qué sede te encuentras?
-                    </span>
-                    <select class="cat-modal-select" id="sedeSelect" onchange="onSedeChange()">
-                        ${selectOpts}
-                    </select>
-                    <span class="cat-modal-sede-hint">Selecciona el local más cercano a ti para continuar con la cotización.</span>
-                    <a id="btnCotizar" href="/agendamientos/" class="cat-modal-cta disabled" onclick="return validarSede(event)">
+                <div class="cat-cot-form">
+                    <h3 class="cat-cot-title">Cotizar motocicleta</h3>
+                    <p class="cat-cot-sub">Completa tus datos para generar el valor total estimado, el radicado y continuar la atención.</p>
+                    <div class="cat-cot-grid">
+                        <div class="cat-cot-field">
+                            <label class="cat-cot-label" for="tipoDocumento">Tipo de documento</label>
+                            <select class="cat-cot-select" id="tipoDocumento">
+                                <option value="CC">Cédula de ciudadanía</option>
+                                <option value="CE">Cédula de extranjería</option>
+                                <option value="PP">Pasaporte</option>
+                            </select>
+                        </div>
+                        <div class="cat-cot-field">
+                            <label class="cat-cot-label" for="numeroDocumento">Número de documento</label>
+                            <input class="cat-cot-input" id="numeroDocumento" type="text" placeholder="Ej: 1023456789">
+                        </div>
+                        <div class="cat-cot-field full">
+                            <label class="cat-cot-label" for="nombreCompleto">Nombre completo</label>
+                            <input class="cat-cot-input" id="nombreCompleto" type="text" placeholder="Ej: Juan Pérez">
+                        </div>
+                        <div class="cat-cot-field">
+                            <label class="cat-cot-label" for="telefonoCotizacion">Número de teléfono</label>
+                            <input class="cat-cot-input" id="telefonoCotizacion" type="text" placeholder="Ej: 3001234567">
+                        </div>
+                        <div class="cat-cot-field">
+                            <label class="cat-cot-label" for="correoCotizacion">Correo electrónico</label>
+                            <input class="cat-cot-input" id="correoCotizacion" type="email" placeholder="correo@ejemplo.com">
+                        </div>
+                        ${sedeSection}
+                        <div class="cat-cot-field full">
+                            <label class="cat-cot-label" for="comentarioCotizacion">Comentario</label>
+                            <input class="cat-cot-input" id="comentarioCotizacion" type="text" placeholder="Ej: Quiero financiar esta motocicleta">
+                        </div>
+                    </div>
+                    <div id="cotizacionMsg" class="cat-cot-msg"></div>
+                    <div class="cat-cot-actions">
+                    <button id="btnCotizar" type="button" class="cat-modal-cta" onclick="enviarCotizacion()">
                         <svg viewBox="0 0 24 24" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round">
                             <path d="M9 11l3 3L22 4"/>
                             <path d="M21 12v7a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h11"/>
                         </svg>
                         Cotizar moto
-                    </a>
+                    </button>
+                    <button type="button" class="cat-cot-secondary" onclick="cerrarModal()">Cancelar</button>
+                    </div>
                 </div>
             </div>`;
+    }
 
+    function abrirModal(id) {
+        const moto = todasLasMotos.find(m => m.id === id);
+        if (!moto) return;
+        renderModalFormulario(moto);
         overlay.classList.add('open');
         document.body.style.overflow = 'hidden';
     }
@@ -867,24 +958,141 @@
         const sel = document.getElementById('sedeSelect');
         const btn = document.getElementById('btnCotizar');
         if (!sel || !btn) return;
-        if (sel.value) {
-            btn.classList.remove('disabled');
-            btn.href = `/agendamientos/?local=${sel.value}`;
-        } else {
-            btn.classList.add('disabled');
-            btn.href = '/agendamientos/';
+        if (!todasLasSedes.some(sede => sede.locales && sede.locales.length)) {
+            return;
         }
     }
 
-    function validarSede(e) {
+    function setCotizacionMsg(message, type = '') {
+        const box = document.getElementById('cotizacionMsg');
+        if (!box) return;
+        box.className = `cat-cot-msg ${type}`.trim();
+        box.textContent = message;
+    }
+
+    function validarFormularioCotizacion() {
+        const nombre = document.getElementById('nombreCompleto')?.value.trim();
+        const telefono = document.getElementById('telefonoCotizacion')?.value.trim();
+        const correo = document.getElementById('correoCotizacion')?.value.trim();
+        const documento = document.getElementById('numeroDocumento')?.value.trim();
+        if (!documento) return 'Ingresa el numero de documento.';
+        if (!nombre) return 'Ingresa el nombre completo.';
+        if (!telefono) return 'Ingresa el numero de telefono.';
+        if (!correo) return 'Ingresa el correo electronico.';
         const sel = document.getElementById('sedeSelect');
-        if (!sel || !sel.value) {
-            e.preventDefault();
-            sel.style.borderColor = '#cc0000';
-            sel.focus();
-            return false;
+        if (todasLasSedes.some(sede => sede.locales && sede.locales.length) && (!sel || !sel.value)) {
+            return 'Selecciona un local para continuar.';
         }
-        return true;
+        return '';
+    }
+
+    async function enviarCotizacion() {
+        if (!motoActual) return;
+        const error = validarFormularioCotizacion();
+        if (error) {
+            setCotizacionMsg(error, 'error');
+            return;
+        }
+
+        const btn = document.getElementById('btnCotizar');
+        const payload = {
+            motocicleta_id: motoActual.id,
+            cliente_nombre: document.getElementById('nombreCompleto')?.value.trim() || '',
+            cliente_correo: document.getElementById('correoCotizacion')?.value.trim() || '',
+            cliente_telefono: document.getElementById('telefonoCotizacion')?.value.trim() || '',
+            comentario: document.getElementById('comentarioCotizacion')?.value.trim() || '',
+        };
+        const localId = document.getElementById('sedeSelect')?.value;
+        if (localId) payload.local_id = Number(localId);
+
+        btn.disabled = true;
+        setCotizacionMsg('Generando cotizacion...', '');
+
+        try {
+            const res = await fetch(API_COTIZAR, {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify(payload),
+            });
+            const data = await res.json();
+            if (!res.ok) {
+                const firstError = Object.values(data)[0];
+                const msg = Array.isArray(firstError) ? firstError[0] : (firstError || 'No se pudo generar la cotizacion.');
+                throw new Error(msg);
+            }
+            renderResumenCotizacion(motoActual, data);
+        } catch (err) {
+            setCotizacionMsg(err.message || 'No se pudo generar la cotizacion.', 'error');
+        } finally {
+            btn.disabled = false;
+        }
+    }
+
+    function renderResumenCotizacion(moto, cotizacion) {
+        const redireccionHtml = cotizacion.whatsapp_url
+            ? `<div id="cotizacionRedirectMsg" class="cat-cot-msg success">Redirigiendo a WhatsApp para continuar la atención...</div>`
+            : `<div id="cotizacionRedirectMsg" class="cat-cot-msg">Cotización generada. Falta configurar un local para continuar por WhatsApp.</div>`;
+        const whatsappHtml = cotizacion.whatsapp_url
+            ? `<a class="cat-modal-cta" href="${cotizacion.whatsapp_url}" target="_blank" rel="noopener noreferrer">Continuar por WhatsApp</a>`
+            : `<button type="button" class="cat-cot-secondary" onclick="renderModalFormulario(motoActual)">Volver al formulario</button>`;
+
+        modalContent.innerHTML = `
+            <div class="cat-modal-left">
+                ${moto.imagen_url
+                    ? `<img class="cat-modal-moto-img" src="${moto.imagen_url}" alt="${moto.referencia}">`
+                    : `<div class="cat-modal-moto-placeholder">${placeholderCard}</div>`}
+                <div class="cat-modal-left-bottom">
+                    <span class="cat-modal-precio-label">Radicado generado</span>
+                    <div><span class="cat-modal-precio-val" style="font-size:1.4rem;">${cotizacion.radicado}</span></div>
+                    <span class="cat-modal-precio-base">Cotizacion creada correctamente</span>
+                </div>
+            </div>
+            <div class="cat-modal-right">
+                <span class="cat-modal-tipo-badge">${moto.tipo_display}</span>
+                <h2 class="cat-modal-nombre">Resumen de cotizacion</h2>
+                <p class="cat-modal-anio-cc">Yamaha ${moto.referencia} · Modelo ${moto.anio}</p>
+                <div class="cat-cot-summary">
+                    <div id="cotizacionMsg" class="cat-cot-msg success">La cotizacion fue generada exitosamente.</div>
+                    ${redireccionHtml}
+                    <div class="cat-cot-summary-grid">
+                        <div class="cat-cot-summary-card">
+                            <span class="cat-cot-summary-label">Precio base</span>
+                            <span class="cat-cot-summary-value">$ ${Number(cotizacion.precio_base).toLocaleString('es-CO')}</span>
+                        </div>
+                        <div class="cat-cot-summary-card">
+                            <span class="cat-cot-summary-label">Impuestos</span>
+                            <span class="cat-cot-summary-value">$ ${Number(cotizacion.impuestos_estimados).toLocaleString('es-CO')}</span>
+                        </div>
+                        <div class="cat-cot-summary-card">
+                            <span class="cat-cot-summary-label">Tramites</span>
+                            <span class="cat-cot-summary-value">$ ${Number(cotizacion.tramites_estimados).toLocaleString('es-CO')}</span>
+                        </div>
+                        <div class="cat-cot-summary-card">
+                            <span class="cat-cot-summary-label">Correo enviado</span>
+                            <span class="cat-cot-summary-value">${cotizacion.correo_cotizacion_enviado ? 'Si' : 'No'}</span>
+                        </div>
+                        <div class="cat-cot-summary-card">
+                            <span class="cat-cot-summary-label">Radicado</span>
+                            <span class="cat-cot-summary-value">${cotizacion.radicado}</span>
+                        </div>
+                        <div class="cat-cot-summary-card">
+                            <span class="cat-cot-summary-label">Local</span>
+                            <span class="cat-cot-summary-value">${cotizacion.local ? cotizacion.local.nombre : 'Pendiente'}</span>
+                        </div>
+                        <div class="cat-cot-summary-card full">
+                            <span class="cat-cot-summary-label">Total estimado</span>
+                            <span class="cat-cot-summary-value cat-cot-summary-total">$ ${Number(cotizacion.total_estimado).toLocaleString('es-CO')}</span>
+                        </div>
+                    </div>
+                    ${whatsappHtml}
+                </div>
+            </div>`;
+
+        if (cotizacion.whatsapp_url) {
+            setTimeout(() => {
+                window.location.href = cotizacion.whatsapp_url;
+            }, 1400);
+        }
     }
 
     function cerrarModal() {


### PR DESCRIPTION
HU-10 - Cotizar motocicleta

### Cambios
- endpoint `POST /api/catalog/cotizaciones/motocicletas/`
- generación de cotización con `radicado`
- cálculo de desglose de costos:
  - precio base
  - impuestos estimados
  - trámites estimados
  - total estimado
- envío opcional de cotización por correo cuando el usuario registra email
- integración del flujo en `frontend/templates/public/motos.html`
- formulario de cotización dentro del modal de detalle de la motocicleta
- vista de resumen después de generar la cotización
- redirección a WhatsApp cuando existe local seleccionado
- soporte para cotizar incluso cuando aún no hay sedes/locales cargados
- el usuario selecciona una motocicleta del catálogo
- el sistema muestra el desglose de costos
- se genera un radicado de cotización
- se permite continuar por WhatsApp cuando hay local disponible

### Tests
- `python manage.py test catalog --verbosity=2`
- `python -m ruff check .`
- `python -m ruff format --check .`

### Checklist
- tests `catalog`: OK
- `ruff check`: OK
- `ruff format --check`: OK

### Notas:
- si no existen sedes/locales cargados, la cotización igual se genera y muestra el resumen
- la redirección a WhatsApp queda disponible cuando el flujo cuenta con un local seleccionado
