### PR TITLE
Hotfix HU-10: anexar cotizacion en mensaje de WhatsApp

### DIFF
--- a/backend/catalog/services.py
+++ b/backend/catalog/services.py
@@ -11,6 +11,7 @@ from catalog.models import CotizacionMotocicleta
 IMPUESTO_RATE = Decimal("0.19")
 TRAMITES_RATE = Decimal("0.08")
 MONEY_STEP = Decimal("0.01")
+WHATSAPP_FALLBACK_NUMBER = "573113252436"
 
 
 def _money(value: Decimal) -> Decimal:
@@ -39,13 +40,24 @@ def calcular_desglose_cotizacion(precio_base: Decimal) -> dict[str, Decimal]:
     }
 
 
-def construir_enlace_whatsapp(telefono: str, radicado: str, nombre_motocicleta: str) -> str:
+def construir_enlace_whatsapp(
+    telefono: str,
+    radicado: str,
+    nombre_motocicleta: str,
+    total_estimado: Decimal,
+) -> str:
     numero = re.sub(r"\D", "", telefono or "")
+    if not numero:
+        numero = WHATSAPP_FALLBACK_NUMBER
     if len(numero) == 10:
         numero = f"57{numero}"
 
     mensaje = (
-        f"Hola, quiero continuar la atencion de mi cotizacion {radicado} para la motocicleta {nombre_motocicleta}."
+        "Hola, realice una cotizacion por su pagina y me interesa conocer mas "
+        "y formalizar el proceso.\n\n"
+        f"Radicado: {radicado}\n"
+        f"Motocicleta: {nombre_motocicleta}\n"
+        f"Total estimado: ${total_estimado}"
     )
     return f"https://wa.me/{numero}?text={quote(mensaje)}"
 

--- a/backend/catalog/tests.py
+++ b/backend/catalog/tests.py
@@ -299,7 +299,8 @@ class CotizarMotocicletaTest(TestCase):
         self.assertEqual(response.data["tramites_estimados"], "800000.00")
         self.assertEqual(response.data["total_estimado"], "12700000.00")
         self.assertIsNone(response.data["local"])
-        self.assertIsNone(response.data["whatsapp_url"])
+        self.assertIn("https://wa.me/573113252436", response.data["whatsapp_url"])
+        self.assertIn(response.data["radicado"], response.data["whatsapp_url"])
         self.assertEqual(CotizacionMotocicleta.objects.count(), 1)
 
     def test_cp_hu10_02_guarda_datos_correctos_en_bd(self):
@@ -381,6 +382,7 @@ class CotizarMotocicletaTest(TestCase):
         self.assertEqual(response.status_code, 201)
         self.assertEqual(response.data["local"]["id"], self.local.id)
         self.assertIn("https://wa.me/573001234567", response.data["whatsapp_url"])
+        self.assertIn(response.data["radicado"], response.data["whatsapp_url"])
 
     def test_cp_hu10_09_usuario_autenticado_queda_asociado(self):
         admin = make_admin(self.local)

--- a/backend/catalog/views.py
+++ b/backend/catalog/views.py
@@ -73,13 +73,12 @@ class CotizarMotocicletaView(APIView):
         )
 
         correo_enviado = enviar_cotizacion_por_correo(cotizacion)
-        whatsapp_url = None
-        if local:
-            whatsapp_url = construir_enlace_whatsapp(
-                local.telefono,
-                cotizacion.radicado,
-                f"{motocicleta.marca} {motocicleta.referencia} {motocicleta.anio}",
-            )
+        whatsapp_url = construir_enlace_whatsapp(
+            local.telefono if local else "",
+            cotizacion.radicado,
+            f"{motocicleta.marca} {motocicleta.referencia} {motocicleta.anio}",
+            cotizacion.total_estimado,
+        )
 
         response_data = CotizacionMotocicletaResponseSerializer(cotizacion).data
         response_data["whatsapp_url"] = whatsapp_url

--- a/frontend/templates/public/motos.html
+++ b/frontend/templates/public/motos.html
@@ -1030,7 +1030,7 @@
 
     function renderResumenCotizacion(moto, cotizacion) {
         const redireccionHtml = cotizacion.whatsapp_url
-            ? `<div id="cotizacionRedirectMsg" class="cat-cot-msg success">Redirigiendo a WhatsApp para continuar la atención...</div>`
+            ? `<div id="cotizacionRedirectMsg" class="cat-cot-msg success">Tu cotización está lista. Puedes continuar por WhatsApp cuando quieras.</div>`
             : `<div id="cotizacionRedirectMsg" class="cat-cot-msg">Cotización generada. Falta configurar un local para continuar por WhatsApp.</div>`;
         const whatsappHtml = cotizacion.whatsapp_url
             ? `<a class="cat-modal-cta" href="${cotizacion.whatsapp_url}" target="_blank" rel="noopener noreferrer">Continuar por WhatsApp</a>`
@@ -1087,12 +1087,6 @@
                     ${whatsappHtml}
                 </div>
             </div>`;
-
-        if (cotizacion.whatsapp_url) {
-            setTimeout(() => {
-                window.location.href = cotizacion.whatsapp_url;
-            }, 1400);
-        }
     }
 
     function cerrarModal() {


### PR DESCRIPTION
### Ajusta el flujo final de HU-10 para incluir el botón de WhatsApp y que no redirija automáticamente y lleve la cotización anexada en el mensaje prellenado.

### Incluye:
- botón de Whatsapp
- eliminación de la redirección automática a WhatsApp
- apertura solo al hacer clic en el botón
- mensaje de WhatsApp con:
  - radicado
  - motocicleta cotizada
  - total estimado
- uso de número fijo temporal cuando aún no exista local configurado

### Archivos:
- `backend/catalog/services.py`
- `backend/catalog/views.py`
- `backend/catalog/tests.py`
- `frontend/templates/public/motos.html`

### Verificación:
- `python manage.py test catalog --verbosity=2`
- `python -m ruff check .`
- `python -m ruff format --check .`
