### PR TITLE
fix(HU-16): corregir carga de datos del local y mejorar frontend

### DIFF
--- a/backend/config/urls.py
+++ b/backend/config/urls.py
@@ -60,6 +60,12 @@ urlpatterns = [
         TemplateView.as_view(template_name="admin_panel/editar_motocicleta.html"),
         name="panel_editar_moto",
     ),
+
+    path(
+    "panel/mi-local/",
+    TemplateView.as_view(template_name="admin_panel/editar_local.html"),
+    name="panel_editar_local",
+    ),
     path("admin/", admin.site.urls),
     path("api/core/", include("core.urls")),
     path("api/users/", include("users.urls")),

--- a/backend/config/urls.py
+++ b/backend/config/urls.py
@@ -60,11 +60,10 @@ urlpatterns = [
         TemplateView.as_view(template_name="admin_panel/editar_motocicleta.html"),
         name="panel_editar_moto",
     ),
-
     path(
-    "panel/mi-local/",
-    TemplateView.as_view(template_name="admin_panel/editar_local.html"),
-    name="panel_editar_local",
+        "panel/mi-local/",
+        TemplateView.as_view(template_name="admin_panel/editar_local.html"),
+        name="panel_editar_local",
     ),
     path("admin/", admin.site.urls),
     path("api/core/", include("core.urls")),

--- a/backend/core/serializers.py
+++ b/backend/core/serializers.py
@@ -30,6 +30,7 @@ class SedeSerializer(serializers.ModelSerializer):
 # lo que el template necesita (nombre, correo_admin, num_mecanicos, activo)
 # y PATCH pueda actualizar los campos editables.
 
+
 class LocalUpdateSerializer(serializers.ModelSerializer):
     """Serializer para edición de información del local (HU-16)."""
 
@@ -39,7 +40,7 @@ class LocalUpdateSerializer(serializers.ModelSerializer):
     class Meta:
         model = Local
         fields = [
-            "nombre",           # read-only, para mostrar en el formulario
+            "nombre",  # read-only, para mostrar en el formulario
             "telefono",
             "direccion",
             "descripcion",

--- a/backend/core/serializers.py
+++ b/backend/core/serializers.py
@@ -24,3 +24,29 @@ class SedeSerializer(serializers.ModelSerializer):
     class Meta:
         model = Sede
         fields = ["id", "nombre", "locales"]
+
+
+# hu 16 — CORREGIDO: se amplían los fields para que GET devuelva todo
+# lo que el template necesita (nombre, correo_admin, num_mecanicos, activo)
+# y PATCH pueda actualizar los campos editables.
+
+class LocalUpdateSerializer(serializers.ModelSerializer):
+    """Serializer para edición de información del local (HU-16)."""
+
+    # read-only: se devuelven en GET pero el PATCH los ignora
+    nombre = serializers.CharField(read_only=True)
+
+    class Meta:
+        model = Local
+        fields = [
+            "nombre",           # read-only, para mostrar en el formulario
+            "telefono",
+            "direccion",
+            "descripcion",
+            "hora_apertura",
+            "hora_cierre",
+            "correo_admin",
+            "num_mecanicos",
+            "activo",
+        ]
+        read_only_fields = ["nombre"]

--- a/backend/core/tests.py
+++ b/backend/core/tests.py
@@ -1,1 +1,71 @@
-# Create your tests here.
+from django.contrib.auth import get_user_model
+from django.test import TestCase
+from rest_framework.test import APIClient
+from rest_framework_simplejwt.tokens import RefreshToken
+from core.models import Local, Municipio, Sede
+
+User = get_user_model()
+
+
+def make_local():
+    municipio = Municipio.objects.create(nombre="Medellin", departamento="Antioquia")
+    sede = Sede.objects.create(nombre="Sede Centro", direccion="Calle 1", municipio=municipio)
+    return Local.objects.create(
+        nombre="Local Centro", sede=sede, direccion="Cra 50",
+        telefono="3001234567", correo_admin="local@test.com",
+        hora_apertura="08:00", hora_cierre="18:00", num_mecanicos=3,
+    )
+
+
+def make_admin(local):
+    user = User.objects.create_user(
+        username="admin1", email="admin@rallye.com",
+        password="Segura123!", local=local,
+    )
+    return user
+
+
+def get_token(user):
+    return str(RefreshToken.for_user(user).access_token)
+
+
+class LocalUpdateTest(TestCase):
+    def setUp(self):
+        self.client = APIClient()
+        self.local = make_local()
+        self.admin = make_admin(self.local)
+        self.url = f"/api/core/locales/{self.local.pk}/editar/"
+
+    def test_admin_puede_actualizar_telefono(self):
+        self.client.credentials(HTTP_AUTHORIZATION=f"Bearer {get_token(self.admin)}")
+        resp = self.client.patch(self.url, {"telefono": "3119999999"}, format="json")
+        self.assertEqual(resp.status_code, 200)
+        self.local.refresh_from_db()
+        self.assertEqual(self.local.telefono, "3119999999")
+
+    def test_admin_puede_actualizar_descripcion(self):
+        self.client.credentials(HTTP_AUTHORIZATION=f"Bearer {get_token(self.admin)}")
+        resp = self.client.patch(self.url, {"descripcion": "Taller especializado"}, format="json")
+        self.assertEqual(resp.status_code, 200)
+        self.local.refresh_from_db()
+        self.assertEqual(self.local.descripcion, "Taller especializado")
+
+    def test_no_autenticado_recibe_401(self):
+        resp = self.client.patch(self.url, {"telefono": "3119999999"}, format="json")
+        self.assertEqual(resp.status_code, 401)
+
+    def test_admin_otro_local_recibe_404(self):
+        otro_local = make_local()
+        otro_admin = User.objects.create_user(
+            username="admin2", email="admin2@rallye.com",
+            password="Segura123!", local=otro_local,
+        )
+        self.client.credentials(HTTP_AUTHORIZATION=f"Bearer {get_token(otro_admin)}")
+        resp = self.client.patch(self.url, {"telefono": "3119999999"}, format="json")
+        self.assertEqual(resp.status_code, 404)
+
+    def test_get_retorna_datos_actuales(self):
+        self.client.credentials(HTTP_AUTHORIZATION=f"Bearer {get_token(self.admin)}")
+        resp = self.client.get(self.url)
+        self.assertEqual(resp.status_code, 200)
+        self.assertEqual(resp.data["telefono"], "3001234567")

--- a/backend/core/tests.py
+++ b/backend/core/tests.py
@@ -11,16 +11,23 @@ def make_local():
     municipio = Municipio.objects.create(nombre="Medellin", departamento="Antioquia")
     sede = Sede.objects.create(nombre="Sede Centro", direccion="Calle 1", municipio=municipio)
     return Local.objects.create(
-        nombre="Local Centro", sede=sede, direccion="Cra 50",
-        telefono="3001234567", correo_admin="local@test.com",
-        hora_apertura="08:00", hora_cierre="18:00", num_mecanicos=3,
+        nombre="Local Centro",
+        sede=sede,
+        direccion="Cra 50",
+        telefono="3001234567",
+        correo_admin="local@test.com",
+        hora_apertura="08:00",
+        hora_cierre="18:00",
+        num_mecanicos=3,
     )
 
 
 def make_admin(local):
     user = User.objects.create_user(
-        username="admin1", email="admin@rallye.com",
-        password="Segura123!", local=local,
+        username="admin1",
+        email="admin@rallye.com",
+        password="Segura123!",
+        local=local,
     )
     return user
 
@@ -57,8 +64,10 @@ class LocalUpdateTest(TestCase):
     def test_admin_otro_local_recibe_404(self):
         otro_local = make_local()
         otro_admin = User.objects.create_user(
-            username="admin2", email="admin2@rallye.com",
-            password="Segura123!", local=otro_local,
+            username="admin2",
+            email="admin2@rallye.com",
+            password="Segura123!",
+            local=otro_local,
         )
         self.client.credentials(HTTP_AUTHORIZATION=f"Bearer {get_token(otro_admin)}")
         resp = self.client.patch(self.url, {"telefono": "3119999999"}, format="json")

--- a/backend/core/urls.py
+++ b/backend/core/urls.py
@@ -1,8 +1,11 @@
 from rest_framework.routers import DefaultRouter
-from core.views import SedeViewSet, LocalViewSet
+from django.urls import path
+from core.views import SedeViewSet, LocalViewSet, LocalUpdateView
 
 router = DefaultRouter()
 router.register("sedes", SedeViewSet, basename="sede")
 router.register("locales", LocalViewSet, basename="local")
 
-urlpatterns = router.urls
+urlpatterns = router.urls + [
+    path("locales/<int:pk>/editar/", LocalUpdateView.as_view(), name="local-update"),
+]

--- a/backend/core/views.py
+++ b/backend/core/views.py
@@ -1,8 +1,11 @@
-# Create your views here.
-from rest_framework.permissions import AllowAny
+# core/views.py
+from rest_framework import status
+from rest_framework.permissions import AllowAny, IsAuthenticated
+from rest_framework.response import Response
+from rest_framework.views import APIView
 from rest_framework.viewsets import ReadOnlyModelViewSet
 from core.models import Local, Sede
-from core.serializers import LocalSerializer, SedeSerializer
+from core.serializers import LocalSerializer, LocalUpdateSerializer, SedeSerializer
 
 
 class SedeViewSet(ReadOnlyModelViewSet):
@@ -15,3 +18,55 @@ class LocalViewSet(ReadOnlyModelViewSet):
     queryset = Local.objects.filter(activo=True).select_related("sede")
     serializer_class = LocalSerializer
     permission_classes = [AllowAny]
+
+
+class LocalUpdateView(APIView):
+    """
+    GET  /api/core/locales/<pk>/editar/  — obtener datos actuales del local
+    PATCH /api/core/locales/<pk>/editar/ — actualizar información del local
+
+    Solo el administrador autenticado asignado a ese local puede editarlo.
+    """
+
+    permission_classes = [IsAuthenticated]
+
+    def _get_local(self, pk, user):
+        """
+        BUG FIX (HU-16): Local.administradores es el related_manager inverso
+        de User.local (FK). Filtrar Local.objects.get(administradores=user)
+        no funciona — genera DoesNotExist siempre.
+        La verificación correcta: el usuario autenticado debe tener
+        user.local_id == pk para poder editar ese local.
+        """
+        if user.local_id is None or user.local_id != pk:
+            return None
+        try:
+            return Local.objects.get(pk=pk)
+        except Local.DoesNotExist:
+            return None
+
+    def get(self, request, pk):
+        local = self._get_local(pk, request.user)
+        if local is None:
+            return Response(
+                {"error": "Local no encontrado o sin permisos."},
+                status=status.HTTP_404_NOT_FOUND,
+            )
+        serializer = LocalUpdateSerializer(local)
+        return Response(serializer.data, status=status.HTTP_200_OK)
+
+    def patch(self, request, pk):
+        local = self._get_local(pk, request.user)
+        if local is None:
+            return Response(
+                {"error": "Local no encontrado o sin permisos."},
+                status=status.HTTP_404_NOT_FOUND,
+            )
+        serializer = LocalUpdateSerializer(local, data=request.data, partial=True)
+        if serializer.is_valid():
+            serializer.save()
+            return Response(
+                {"mensaje": "Información del local actualizada correctamente."},
+                status=status.HTTP_200_OK,
+            )
+        return Response(serializer.errors, status=status.HTTP_400_BAD_REQUEST)

--- a/backend/users/urls.py
+++ b/backend/users/urls.py
@@ -1,8 +1,9 @@
-from django.urls import path
 
-from users.views import LoginView, LogoutView
+from django.urls import path
+from users.views import LoginView, LogoutView, UserProfileView
 
 urlpatterns = [
     path("login/", LoginView.as_view(), name="api_login"),
     path("logout/", LogoutView.as_view(), name="api_logout"),
+    path("profile/", UserProfileView.as_view(), name="api_profile"),
 ]

--- a/backend/users/urls.py
+++ b/backend/users/urls.py
@@ -1,4 +1,3 @@
-
 from django.urls import path
 from users.views import LoginView, LogoutView, UserProfileView
 

--- a/backend/users/views.py
+++ b/backend/users/views.py
@@ -94,13 +94,16 @@ class UserProfileView(APIView):
     GET /api/users/profile/
     Retorna información del usuario autenticado
     """
+
     permission_classes = [IsAuthenticated]
 
     def get(self, request):
         user = request.user
-        return Response({
-            "email": user.email,
-            "username": user.username,
-            "local_id": user.local.id if user.local else None,
-            "local_nombre": user.local.nombre if user.local else None,
-        })
+        return Response(
+            {
+                "email": user.email,
+                "username": user.username,
+                "local_id": user.local.id if user.local else None,
+                "local_nombre": user.local.nombre if user.local else None,
+            }
+        )

--- a/backend/users/views.py
+++ b/backend/users/views.py
@@ -87,3 +87,20 @@ class LogoutView(APIView):
             return Response({"message": "Sesión cerrada correctamente."}, status=status.HTTP_200_OK)
         except Exception:
             return Response({"error": "Token inválido o ya expirado."}, status=status.HTTP_400_BAD_REQUEST)
+
+
+class UserProfileView(APIView):
+    """
+    GET /api/users/profile/
+    Retorna información del usuario autenticado
+    """
+    permission_classes = [IsAuthenticated]
+
+    def get(self, request):
+        user = request.user
+        return Response({
+            "email": user.email,
+            "username": user.username,
+            "local_id": user.local.id if user.local else None,
+            "local_nombre": user.local.nombre if user.local else None,
+        })


### PR DESCRIPTION
- core/views.py: corregir _get_local() que usaba filtro Local.objects.get(administradores=user) incorrecto (related_manager inverso). Ahora verifica user.local_id == pk correctamente.

- core/serializers.py: ampliar LocalUpdateSerializer con campos nombre (read_only), correo_admin, num_mecanicos y activo que el template requería pero no se devolvían en el GET.

- templates/admin_panel/editar_local.html: rediseño completo del formulario con tema oscuro consistente, validación por campo, toast notifications y mejor manejo de errores del servidor.

- templates/admin_panel/dashboard.html: corregir link de navbar LOCAL que apuntaba a /panel/disponibilidad/ en lugar de /panel/mi-local/.

Closes HU-16